### PR TITLE
33 bug on delete relaxed in relinklistcontainer

### DIFF
--- a/projects/emfular/src/lib/referencing/referencable/container/link/re-link-list-container.ts
+++ b/projects/emfular/src/lib/referencing/referencable/container/link/re-link-list-container.ts
@@ -45,6 +45,12 @@ implements ReLinkContainer<T, P> {
         return res; //todo behaviour of flag different to add??
     }
 
+    override delete(mode: DeletionMode = DeletionMode.RELAXED): void {
+        while (this._instance.length > 0) {
+            this.remove(this._instance[0], mode);
+        }
+    }
+
     removeFromInverse(item: T, mode: DeletionMode = DeletionMode.RELAXED): boolean {
         if(this.inverseName !== undefined) {
             for (const child of [...this._instance]) {

--- a/projects/emfular/src/lib/referencing/test/delete-on-re-containers.spec.ts
+++ b/projects/emfular/src/lib/referencing/test/delete-on-re-containers.spec.ts
@@ -1,0 +1,64 @@
+import {Middle2WithChildren, ReChild3, RootWithChildren} from "./referencables-with-children";
+import {DeletionMode} from "../../utils/deletion-mode";
+
+describe('ReContainer delete tests', () => {
+    it("should relaxed delete re-tree-container correctly", () =>{
+        let root = new RootWithChildren();
+        let child1 = new ReChild3();
+        let child2 = new ReChild3();
+        let middle = new Middle2WithChildren();
+        root.link3.push(child1,child2);
+        middle.child3.push(child1,child2);
+        expect(root.link3.length).toBe(2);
+        expect(child1.link1).toContain(root);
+        expect(child2.link1).toContain(root);
+        expect(middle.child3.length).toBe(2);
+        expect(child1.parentPointer).toEqual(middle);
+        expect(child2.parentPointer).toEqual(middle);
+        middle.child3.delete();
+        expect(root.link3.length).toBe(2);
+        expect(middle.child3.length).toBe(0);
+        expect(child1.parentPointer).toBeUndefined();
+        expect(child2.parentPointer).toBeUndefined();
+    })
+
+    it("should cascade delete re-tree-container correctly", () =>{
+        let root = new RootWithChildren();
+        let child1 = new ReChild3();
+        let child2 = new ReChild3();
+        let middle = new Middle2WithChildren();
+        root.link3.push(child1,child2);
+        middle.child3.push(child1,child2);
+        expect(root.link3.length).toBe(2);
+        expect(child1.link1).toContain(root);
+        expect(child2.link1).toContain(root);
+        expect(middle.child3.length).toBe(2);
+        expect(child1.parentPointer).toEqual(middle);
+        expect(child2.parentPointer).toEqual(middle);
+        middle.child3.delete();
+        expect(root.link3.length).toBe(2);
+        expect(middle.child3.length).toBe(0);
+        expect(child1.parentPointer).toBeUndefined();
+        expect(child2.parentPointer).toBeUndefined();
+    })
+
+    it("should delete re-list-container correctly", () =>{
+        let root = new RootWithChildren();
+        let child1 = new ReChild3();
+        let child2 = new ReChild3();
+        let middle = new Middle2WithChildren();
+        root.link3.push(child1,child2);
+        middle.child3.push(child1,child2);
+        expect(root.link3.length).toBe(2);
+        expect(child1.link1).toContain(root);
+        expect(child2.link1).toContain(root);
+        expect(middle.child3.length).toBe(2);
+        expect(child1.parentPointer).toEqual(middle);
+        expect(child2.parentPointer).toEqual(middle);
+        root.link3.delete();
+        expect(root.link3.length).toBe(0);
+        expect(middle.child3.length).toBe(2);
+        expect(child1.parentPointer).toBeDefined();
+        expect(child2.parentPointer).toBeDefined();
+    })
+});


### PR DESCRIPTION
Calling delete with relaxed mode on a non-containment reference caused an infinite loop in method destructAllFromChanging list, because the elements where removed from the parent list and not desired non-containment reference